### PR TITLE
Update to support changes to AbstractPlotting 0.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
 OnlineStats = "a15396b6-48d5-5d58-9928-6d29437db91e"
 
 [compat]
-AbstractPlotting = "0.12, 0.13, 0.14, 0.15"
+AbstractPlotting = "0.15"
 ColorSchemes = "3.10"
 Colors = "0.12"
 DynamicPPL = "0.9, 0.10"

--- a/src/Turkie.jl
+++ b/src/Turkie.jl
@@ -67,7 +67,7 @@ function TurkieCallback(vars::Dict, params::Dict)
     axis_dict = Dict()
     for (i, (variable, plots)) in enumerate(vars)
         data[variable] = MovingWindow(window, Float32)
-        axis_dict[(variable, :varname)] = layout[i, 1, Left()] = LText(scene, string(variable), textsize = 30)
+        axis_dict[(variable, :varname)] = layout[i, 1, Left()] = Label(scene, string(variable), textsize = 30)
         axis_dict[(variable, :varname)].padding = (0, 50, 0, 0)
         onlineplot!(scene, layout, axis_dict, plots, iter, data, variable, i)
     end

--- a/src/online_stats_plots.jl
+++ b/src/online_stats_plots.jl
@@ -1,6 +1,6 @@
 function onlineplot!(scene, layout, axis_dict, stats::Series, iter, data, variable, i)
     for (j, stat) in enumerate(stats.stats)
-        axis_dict[(variable, stat)] = layout[i, j] = LAxis(scene, title = "$(name(stat))")
+        axis_dict[(variable, stat)] = layout[i, j] = Axis(scene, title = "$(name(stat))")
         onlineplot!(axis_dict[(variable, stat)], stat, iter, data[variable], data[:iter], i, j)
         tight_ticklabel_spacing!(axis_dict[(variable, stat)])
     end
@@ -8,7 +8,7 @@ end
 
 function onlineplot!(scene, layout, axis_dict, stats::AbstractVector, iter, data, variable, i)
     for (j, stat) in enumerate(stats)
-        axis_dict[(variable, stat)] = layout[i, j] = LAxis(scene, title = "$(name(stat))")
+        axis_dict[(variable, stat)] = layout[i, j] = Axis(scene, title = "$(name(stat))")
         onlineplot!(axis_dict[(variable, stat)], stat, iter, data[variable], data[:iter], i, j)
         tight_ticklabel_spacing!(axis_dict[(variable, stat)])
     end


### PR DESCRIPTION
1. Updates function names for `LText => Label`, and `LAxis => Axis`. 
2. Project.toml compat for AbstractPlotting changed to 0.15.

The above function names in [AbstractPlotting.MakieLayout](https://github.com/JuliaPlots/AbstractPlotting.jl) were changed in version [0.15](https://github.com/JuliaPlots/AbstractPlotting.jl/compare/v0.14.4...v0.15.0).